### PR TITLE
thread-localized BaseImageQuery._stored_images/_deleted_images

### DIFF
--- a/sqlalchemy_imageattach/util.py
+++ b/sqlalchemy_imageattach/util.py
@@ -10,7 +10,7 @@ import re
 import textwrap
 
 __all__ = ('append_docstring', 'append_docstring_attributes',
-           'get_minimum_indent')
+           'classproperty', 'get_minimum_indent')
 
 
 def get_minimum_indent(docstring, ignore_before=1):
@@ -102,3 +102,11 @@ def append_docstring_attributes(docstring, locals):
             *lines
         )
     return docstring
+
+
+class classproperty(object):
+    def __init__(self, getter):
+        self.getter = getter
+
+    def __get__(self, instance, owner):
+        return self.getter(owner)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
-from sqlalchemy_imageattach.util import append_docstring, get_minimum_indent
+from sqlalchemy_imageattach.util import (append_docstring, classproperty,
+                                         get_minimum_indent)
 
 
 def test_minimum_indent():
@@ -52,3 +53,14 @@ def test_append_docstring():
 
            Appended docstring!
     '''.rstrip()
+
+
+def test_classproperty():
+
+    class Foo(object):
+        @classproperty
+        def bar(cls):
+            return 'baz'
+
+    assert Foo.bar == 'baz'
+    assert Foo().bar == 'baz'


### PR DESCRIPTION
Faced an issue that session state be corrupted due to `BaseImageQuery._stored_images`/`._deleted_images` when we use gevent-based WSGI container and it gets  high workload. To resolve converted that containers to thread(gevent)-local storage.